### PR TITLE
Adds support for cocoapods frameworks

### DIFF
--- a/ios/EmailChecker.podspec
+++ b/ios/EmailChecker.podspec
@@ -20,5 +20,6 @@ Pod::Spec.new do |s|
   s.library      = 'c++'
   s.source       = { :git => "https://github.com/wordpress-mobile/EmailChecker.git", :tag => "0.1" }
   s.source_files = 'ios/EmailChecker/**/*.{h,mm}', 'common/**/*.{h,cpp}'
+  s.private_header_files = 'common/**/*.h'
 
 end


### PR DESCRIPTION
Only includes EmailChecker.h as a public header.
Otherwise, Xcode gets confused with C++ imports in a framework
